### PR TITLE
chore(afterFetch & beforeFetch): improve types

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,26 +45,26 @@ export interface HistoryOptions<K> {
   ignore?: Array<K>
 }
 
-export interface Config<O, Result> {
-  fetcher: (params: object) => Promise<Result>
-  conditions?: O
+export interface Config<Result = unknown, Cond = object, AfterResult extends unknown = Result> {
+  fetcher: (...args: any) => Promise<Result>
+  conditions?: Cond
   defaultParams?: object
   immediate?: boolean
   manual?: boolean
   initialData?: any
-  history?: HistoryOptions<keyof O>
+  history?: HistoryOptions<keyof Cond>
   pollingInterval?: number | Ref<number>
   pollingWhenHidden?: boolean
   pollingWhenOffline?: boolean
   revalidateOnFocus?: boolean
   cacheProvider?: () => Cache<any>
-  beforeFetch?: (conditions: O & ConditionsType, cancel: Fn) => ConditionsType
-  afterFetch?: (data: Result) => any
+  beforeFetch?: (conditions: Cond & ConditionsType, cancel: Fn) => ConditionsType
+  afterFetch?: (data: Result) => AfterResult extends Result ? Result : AfterResult
   onFetchError?: (ctx: OnFetchErrorContext) => Promise<Partial<OnFetchErrorContext>> | Partial<OnFetchErrorContext>
 }
 
-export interface UseConditionWatcherReturn<O, Result> {
-  conditions: UnwrapNestedRefs<O>
+export interface UseConditionWatcherReturn<Result, Cond> {
+  conditions: UnwrapNestedRefs<Cond>
   readonly isFetching: Ref<boolean>
   readonly loading: Ref<boolean>
   readonly data: DeepReadonly<Ref<Result | undefined>>
@@ -72,7 +72,7 @@ export interface UseConditionWatcherReturn<O, Result> {
   execute: (throwOnFailed?: boolean) => void
   mutate: Mutate
   resetConditions: (conditions?: object) => void
-  onConditionsChange: (fn: OnConditionsChangeContext<O>) => void
+  onConditionsChange: (fn: OnConditionsChangeContext<Cond>) => void
   onFetchSuccess: (fn: (response: any) => void) => void
   onFetchError: (fn: (error: any) => void) => void
   onFetchFinally: (fn: (error: any) => void) => void


### PR DESCRIPTION
# Changes
1. Sync afterFetch Fn return type to finally data type
  - before
<img width="344" alt="截圖 2022-04-14 下午4 34 38" src="https://user-images.githubusercontent.com/50637947/163348068-f41adcc6-93a5-4efe-bf61-add760c1696d.png">

  - after
<img width="335" alt="截圖 2022-04-14 下午4 34 23" src="https://user-images.githubusercontent.com/50637947/163348084-cc2fffc8-1ebd-44bc-97fc-de72bf815842.png">

2. Update generics orders
  - before: <Cond, Result>
  - after: <Result, Cond, AfterResult, AfterCond>
