### PR TITLE
Fix utility bugs and add tests

### DIFF
--- a/_internal/utils/createEvents.ts
+++ b/_internal/utils/createEvents.ts
@@ -41,11 +41,12 @@ function createFocusEvent(eventHook) {
 }
 
 function createVisibilityEvent(eventHook) {
+  const handler = () => eventHook.trigger(isDocumentVisibility())
   if (hasDoc && document.addEventListener) {
-    document.addEventListener('visibilitychange', () => eventHook.trigger(isDocumentVisibility()))
+    document.addEventListener('visibilitychange', handler)
   }
   return () => {
-    document.removeEventListener('visibilitychange', () => eventHook.trigger(isDocumentVisibility()))
+    document.removeEventListener('visibilitychange', handler)
   }
 }
 

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -24,7 +24,7 @@ export const isNoData = (data: unknown) => {
     return false
   }
   if (isObject(data)) {
-    return Object.keys.length === 0
+    return Object.keys(data).length === 0
   }
   return !data
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -7,6 +7,7 @@ import {
   deepClone,
   typeOf,
   pick,
+  isNoData,
 } from 'vue-condition-watcher/_internal'
 import { describe, expect, test } from 'vitest'
 
@@ -208,5 +209,16 @@ describe('utils: pick', () => {
       name: 'runkids',
       age: 20,
     })
+  })
+})
+
+describe('utils: isNoData', () => {
+  test('should return true for empty object', () => {
+    expect(isNoData({})).toBe(true)
+  })
+
+  test('should return true for undefined', () => {
+    // undefined data should be treated as no data
+    expect(isNoData(undefined)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- fix `isNoData` empty object check
- ensure visibility event uses the same handler in `createEvents`
- add test coverage for `isNoData`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-7.5.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_683feb69436883239703395febafeb72