### PR TITLE
Refactor cache system and improve typings

### DIFF
--- a/_internal/composable/useCache.ts
+++ b/_internal/composable/useCache.ts
@@ -3,13 +3,13 @@ import { serializeFunc, sortObject, stringifyQuery } from '../utils/common'
 
 export function useCache(fetcher: (params: object) => Promise<any>, provider: Cache) {
   const baseKey = serializeFunc(fetcher)
-  function formatString(key) {
+  function formatKey(key) {
     return `${baseKey}@${stringifyQuery(sortObject(key))}`
   }
   return {
-    set: (key, value) => provider.set(formatString(key), value),
-    get: (key) => (provider.get(formatString(key)) ? provider.get(formatString(key)) : undefined),
-    delete: (key) => provider.delete(formatString(key)),
-    cached: (key) => provider.get(formatString(key)) !== undefined,
+    set: (key, value, ttl?: number) => provider.set(formatKey(key), value, ttl),
+    get: (key) => provider.get(formatKey(key)),
+    delete: (key) => provider.delete(formatKey(key)),
+    cached: (key) => provider.has(formatKey(key)),
   }
 }

--- a/_internal/composable/useCache.ts
+++ b/_internal/composable/useCache.ts
@@ -1,10 +1,11 @@
 import { Cache } from '../types'
-import { serializeFunc, sortObject, stringifyQuery } from '../utils/common'
+import { sortObject } from '../utils/common'
+import { getFetcherId } from '../utils/fetcherId'
 
 export function useCache(fetcher: (params: object) => Promise<any>, provider: Cache) {
-  const baseKey = serializeFunc(fetcher)
-  function formatKey(key) {
-    return `${baseKey}@${stringifyQuery(sortObject(key))}`
+  const baseKey = getFetcherId(fetcher)
+  function formatKey(key: Record<string, any>) {
+    return `${baseKey}@${JSON.stringify(sortObject(key))}`
   }
   return {
     set: (key, value, ttl?: number) => provider.set(formatKey(key), value, ttl),

--- a/_internal/composable/usePolling.ts
+++ b/_internal/composable/usePolling.ts
@@ -1,0 +1,64 @@
+import { Ref, ref, unref, watchEffect } from 'vue-demi'
+
+/** Configuration for polling behaviour */
+export interface PollingOptions {
+  interval: number | Ref<number>
+  whenHidden?: boolean
+  whenOffline?: boolean
+  isActive: Ref<boolean>
+  isOnline: Ref<boolean>
+  error: Ref<any>
+  callback: () => Promise<any>
+}
+
+/**
+ * Handle polling logic separately.
+ */
+export function usePolling(options: PollingOptions) {
+  const timer = ref<() => void>()
+  const {
+    interval,
+    whenHidden = false,
+    whenOffline = false,
+    isActive,
+    isOnline,
+    error,
+    callback,
+  } = options
+
+  watchEffect((onCleanup) => {
+    const intv = unref(interval)
+    if (intv) {
+      timer.value = (() => {
+        let id: any = null
+        function next() {
+          const i = unref(interval)
+          if (i && id !== -1) {
+            id = setTimeout(run, i)
+          }
+        }
+        function run() {
+          if (
+            !error.value &&
+            (whenHidden || isActive.value) &&
+            (whenOffline || isOnline.value)
+          ) {
+            callback().then(next)
+          } else {
+            next()
+          }
+        }
+        next()
+        return () => id && clearTimeout(id)
+      })()
+    }
+
+    onCleanup(() => {
+      timer.value && timer.value()
+    })
+  })
+
+  return () => {
+    timer.value && timer.value()
+  }
+}

--- a/_internal/index.ts
+++ b/_internal/index.ts
@@ -1,10 +1,11 @@
 import { usePromiseQueue } from './composable/usePromiseQueue'
 import { useHistory } from './composable/useHistory'
 import { useCache } from './composable/useCache'
+import { usePolling } from './composable/usePolling'
 import { createEvents } from './utils/createEvents'
 import { MemoryCache } from './utils/memoryCache'
 
-export { usePromiseQueue, useHistory, useCache, createEvents, MemoryCache }
+export { usePromiseQueue, useHistory, useCache, usePolling, createEvents, MemoryCache }
 
 export * from './utils/common'
 export * from './utils/helper'

--- a/_internal/index.ts
+++ b/_internal/index.ts
@@ -2,8 +2,9 @@ import { usePromiseQueue } from './composable/usePromiseQueue'
 import { useHistory } from './composable/useHistory'
 import { useCache } from './composable/useCache'
 import { createEvents } from './utils/createEvents'
+import { MemoryCache } from './utils/memoryCache'
 
-export { usePromiseQueue, useHistory, useCache, createEvents }
+export { usePromiseQueue, useHistory, useCache, createEvents, MemoryCache }
 
 export * from './utils/common'
 export * from './utils/helper'

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -1,6 +1,8 @@
 type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
 export type Arguments = string | ArgumentsTuple | Record<any, any> | null | undefined | false
+/** Type used as cache key */
 export type Key = Arguments | (() => Arguments)
+/** Basic cache interface used by the composables */
 export interface Cache<Data = any> {
   /** Check if a value exists and not expired */
   has(key: Key): boolean
@@ -12,6 +14,9 @@ export interface Cache<Data = any> {
   delete(key: Key): void
 }
 
+/**
+ * Options used when synchronizing conditions with browser history.
+ */
 export interface HistoryOptions<K> {
   sync: {
     currentRoute: any

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -2,8 +2,13 @@ type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
 export type Arguments = string | ArgumentsTuple | Record<any, any> | null | undefined | false
 export type Key = Arguments | (() => Arguments)
 export interface Cache<Data = any> {
-  get(key: Key): Data | null | undefined
-  set(key: Key, value: Data): void
+  /** Check if a value exists and not expired */
+  has(key: Key): boolean
+  /** Get cached value */
+  get(key: Key): Data | undefined
+  /** Set cache value with optional ttl(ms) */
+  set(key: Key, value: Data, ttl?: number): void
+  /** Delete cache entry */
   delete(key: Key): void
 }
 

--- a/_internal/utils/common.ts
+++ b/_internal/utils/common.ts
@@ -183,29 +183,3 @@ export function pick(obj: Record<string, any>, keys: string[]) {
   return res
 }
 
-export function serializeFunc(fn) {
-  //the source code from https://github.com/yahoo/serialize-javascript/blob/main/index.js
-  const serializedFn = fn.toString()
-  if (/function.*?\(/.test(serializedFn)) {
-    return serializedFn
-  }
-  if (/.*?=>.*?/.test(serializedFn)) {
-    return serializedFn
-  }
-  const argsStartsAt = serializedFn.indexOf('(')
-  const def = serializedFn
-    .substr(0, argsStartsAt)
-    .trim()
-    .split(' ')
-    .filter((val) => val.length > 0)
-  const nonReservedSymbols = def.filter((val) => ['*', 'async'].indexOf(val) === -1)
-  if (nonReservedSymbols.length > 0) {
-    return (
-      (def.indexOf('async') > -1 ? 'async ' : '') +
-      'function' +
-      (def.join('').indexOf('*') > -1 ? '*' : '') +
-      serializedFn.substr(argsStartsAt)
-    )
-  }
-  return serializedFn
-}

--- a/_internal/utils/createEvents.ts
+++ b/_internal/utils/createEvents.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+/**
+ * Unified event hooks for focus, visibility and reconnect events.
+ * Also provides custom event channels for fetch lifecycle.
+ */
 import { hasDocument, hasWindow, isDocumentVisibility } from './helper'
 
 // These function inspired from VueUse's `createEventHook`

--- a/_internal/utils/fetcherId.ts
+++ b/_internal/utils/fetcherId.ts
@@ -1,0 +1,12 @@
+export const fetcherIds = new WeakMap<Function, string>()
+let counter = 0
+
+export function getFetcherId(fn: Function): string {
+  let id = fetcherIds.get(fn)
+  if (!id) {
+    counter += 1
+    id = `F${counter}`
+    fetcherIds.set(fn, id)
+  }
+  return id
+}

--- a/_internal/utils/memoryCache.ts
+++ b/_internal/utils/memoryCache.ts
@@ -1,0 +1,39 @@
+import { Cache, Key } from '../types'
+
+/**
+ * Simple in-memory cache with TTL support.
+ */
+export class MemoryCache<T = any> implements Cache<T> {
+  private store = new Map<string, { value: T; expires?: number }>()
+
+  private ensure(key: string) {
+    const item = this.store.get(key)
+    if (item && item.expires && Date.now() > item.expires) {
+      this.store.delete(key)
+    }
+  }
+
+  has(key: Key): boolean {
+    const k = String(key)
+    this.ensure(k)
+    return this.store.has(k)
+  }
+
+  get(key: Key): T | undefined {
+    const k = String(key)
+    this.ensure(k)
+    return this.store.get(k)?.value
+  }
+
+  set(key: Key, value: T, ttl?: number): void {
+    const k = String(key)
+    this.store.set(k, {
+      value,
+      expires: ttl ? Date.now() + ttl : undefined,
+    })
+  }
+
+  delete(key: Key): void {
+    this.store.delete(String(key))
+  }
+}

--- a/core/types.ts
+++ b/core/types.ts
@@ -46,6 +46,10 @@ export interface Config<ConditionT = Record<string, any>, ResponseT = unknown, T
   pollingWhenOffline?: boolean
   revalidateOnFocus?: boolean
   cacheProvider?: () => Cache<any>
+  /**
+   * Time-to-live in milliseconds for cache entries.
+   */
+  cacheTtl?: number
   beforeFetch?: (
     conditions: Partial<ConditionT> & Record<string, any>,
     cancel: VoidFn


### PR DESCRIPTION
## Summary
- expand `Cache` interface with TTL support
- implement `MemoryCache` provider
- update `useCache` to use new interface
- clarify generics and docs in core types
- switch default cache provider to `MemoryCache`

## Testing
- `npm run types:check` *(fails: turbo missing)*
- `npm test` *(fails: cannot fetch pnpm)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fec0f2a5483238c5660d3863b2f0d